### PR TITLE
resolver: Add missing slash in paths

### DIFF
--- a/test/resolver.js
+++ b/test/resolver.js
@@ -129,4 +129,12 @@ describe('QuickStart Resolver', function() {
     }
   });
 
+  it('should always have a trailing slash in paths', function() {
+    var resolver = new Resolver({defaultPath: 'folder'});
+    var paths = resolver._paths('folder');
+    for (var i = 0, l = paths.length; i < l; i++) {
+      expect(paths[i].substr(-1, 1)).to.equal('/');
+    }
+  });
+
 });

--- a/util/resolver.js
+++ b/util/resolver.js
@@ -209,7 +209,7 @@ var Resolver = prime({
       paths.push(dir);
     }
     paths.push(drive + '/');
-    if (this.defaultPath) paths.push(this.defaultPath);
+    if (this.defaultPath) paths.push(this.defaultPath + '/');
     return paths;
   },
 


### PR DESCRIPTION
This missing slash resulted in paths like this:

```
folder/folderpackage.json
```
