### PR TITLE
Remove JSON optimizations (fix #10)

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -148,4 +148,16 @@ describe('quickstart', function() {
 
   });
 
+  it('should require JSON files', function() {
+
+    return expect(quickstart({
+      root: __dirname + '/root/',
+      runtime: '../../runtime/node',
+      main: './test-json'
+    }).then(function(result) {
+      eval(result.source);
+    })).to.be.fulfilled;
+
+  });
+
 });

--- a/test/root/test-json.js
+++ b/test/root/test-json.js
@@ -1,0 +1,18 @@
+/* jshint strict:false */
+
+var expect = require('chai').expect;
+
+var jsonModule = require('./module.json');
+expect(jsonModule).to.be.an('object');
+expect(jsonModule.animals).to.be.an('array');
+
+var animals = require('./module.json').animals;
+expect(animals).to.be.an('array');
+
+var animals2 = require('./module.json')['animals'];
+expect(animals2).to.be.an('array');
+
+var hasProperty = require('./module.json').hasOwnProperty('animals');
+expect(hasProperty).to.equal(true);
+
+module.exports = 'test-json';


### PR DESCRIPTION
There are some JSON optimizations in QuickStart that turned out to cause problems in some cases. Since the optimizations are not really needed, we might as well just remove them and treat the
require statements of JSON files the same as other files.

The optimizations would previously do the following conversion at build-time:

file.json:

```json
{"name": "Foo"}
```

index.js:

```js
var name = require('./file.json').name;
// -->
var name = 'Foo';
```

That meant that if nothing else was used from the JSON file, the JSON file itself would never be included in the built file. However, this is causing issues when the accessed property is actually supposed to refer to the evaluated result of the JSON file, as seen in this example:

```js
// assume a JSON file of ['Foo', 'Bar']
var names = require('./names').join(', ');
```