### PR TITLE
modified router to not DIE on invalid left-hand (key) routes.

### DIFF
--- a/test/root/package.json
+++ b/test/root/package.json
@@ -4,6 +4,7 @@
   "browser": {
     "fs": "./lib/fs",
     "./old": "./new",
+    "./invalid-route": "./anything-really",
     "one/old": "./new",
     "./false": false,
     "four": false

--- a/util/resolver.js
+++ b/util/resolver.js
@@ -96,7 +96,9 @@ var Resolver = prime({
           } else {
             control.save(null).continue();
           }
-        }, control.reject);
+        }, function() {
+          control.save(null).continue();
+        });
 
       }
 


### PR DESCRIPTION
  - In reality, it should DIE on invalid key rules, but some packages are routing test files, which may not be present when installed through npm.
  - This makes it so invalid keys are simply ignored.
  - There needs to be no new test, the test is that the package.json in the tests folder now includes an invalid route key, and that all the resolver tests still pass.