### PR TITLE
Add support for NODE_PATH

### DIFF
--- a/util/resolver.js
+++ b/util/resolver.js
@@ -219,13 +219,24 @@ var Resolver = prime({
   resolvePackage: function(path, packageName) {
     var self = this;
     var node_modules = self.nodeModules;
+    var nodePath = process.env['NODE_PATH'];
 
     path = pathogen.resolve(pathogen.dirname(path));
 
     var paths = self._paths(path);
 
+    paths = paths.map(function(path) {
+      return path + '/' + node_modules;
+    });
+
+    if (nodePath) {
+      paths = nodePath.split(path.delimiter).filter(function(path) {
+        return !!path;
+      }).concat(paths);
+    }
+
     return sequence.find(paths, function(path) {
-      var jsonPath = path + node_modules + '/' + packageName + '/package.json';
+      var jsonPath = path + '/' + packageName + '/package.json';
 
       return transport(jsonPath).then(function() {
         return jsonPath;


### PR DESCRIPTION
 By changing a little bit the logic in the path builder, we can add support for custom paths, giving people the possibility of extending the resolver with custom paths.
